### PR TITLE
fix(build): issue replacing version in resources, remove use of blossom

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,7 +53,7 @@ body:
       value: |
         Operating System: <!-- e.g. Windows 11 or Ubuntu 22.04 -->
         Platform: <!-- e.g. BungeeCord 1.20 -->
-        UltraStaffChat Version: <!-- e.g. 5.2.0 -->
+        UltraStaffChat Version: <!-- e.g. 5.2.1 -->
       render: Markdown
     validations:
       required: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,8 +10,8 @@ address security vulnerabilities that affect the most recent version of this plu
 
 | Version   | Supported          |
 |-----------|--------------------|
-| `5.2.0`   | :white_check_mark: |
-| < `5.2.0` | :x:                |
+| `5.2.x`   | :white_check_mark: |
+| < `5.2.x` | :x:                |
 
 ### Reporting a Vulnerability
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -27,7 +27,6 @@ repositories {
 dependencies {
     implementation(libs.build.indra.common)
     implementation(libs.build.indra.publishing)
-    implementation(libs.build.blossom)
     implementation(libs.build.errorprone.plugin)
 }
 

--- a/build-logic/src/main/kotlin/ultrastaffchat.common.gradle.kts
+++ b/build-logic/src/main/kotlin/ultrastaffchat.common.gradle.kts
@@ -22,7 +22,6 @@ plugins {
     id("ultrastaffchat.publishing")
     id("net.kyori.indra")
     id("net.kyori.indra.git")
-    id("net.kyori.blossom")
     id("net.ltgt.errorprone")
 }
 
@@ -35,8 +34,10 @@ indra {
     }
 }
 
-blossom {
-    replaceToken("@version@", rootProject.version)
+tasks.processResources {
+    filter {
+        it.replace("@version@", rootProject.version as String)
+    }
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 }
 
 group = "dev.hypera"
-version = "5.2.0"
+version = "5.2.1"
 description = "A fully customisable staff communication plugin for BungeeCord!"
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,6 @@ annotations = "24.0.1"
 
 # Build
 build-indra = "3.1.1"
-build-blossom = "1.3.1"
 build-errorprone = "2.19.1"
 build-errorprone-plugin = "3.1.0"
 build-shadow = "8.1.1"
@@ -41,7 +40,6 @@ annotations = { module = "org.jetbrains:annotations", version.ref = "annotations
 # Build
 build-indra-common = { module = "net.kyori:indra-common", version.ref = "build-indra" }
 build-indra-publishing = { module = "net.kyori:indra-publishing-gradle-plugin", version.ref = "build-indra" }
-build-blossom = { module = "net.kyori:blossom", version.ref = "build-blossom" }
 build-errorprone-plugin = { module = "net.ltgt.gradle:gradle-errorprone-plugin", version.ref = "build-errorprone-plugin" }
 build-errorprone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "build-errorprone" }
 build-errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "build-errorprone" }


### PR DESCRIPTION
**Summary**
*Bumps version to v5.2.1*
This pull request fixes an issue that caused `@version@` to not be replaced in resources.

<!-- A short summary of what this pull request's intentions are.  -->
<!-- If this pull request resolves an issue, add "Fixes #<id>" at the end of your summary. -->

**Changes**
 - Bump version to v5.2.1
 - Fix an issue that caused `@version@` to not be replaced in resources
 - Remove use of KyoriPowered/Blossom
<!-- A list of changes this pull request makes  -->

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [GNU General Public License v3 or later](https://github.com/HyperaDev/UltraStaffChat/blob/main/LICENSE).
- [x] I have read and agree to follow the [Code of Conduct](https://github.com/HyperaDev/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API or contains configuration changes, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
