### PR TITLE
fix!: update BungeeCord to v1.20-R0.3-SNAPSHOT and fix StaffJoinEvent

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,9 +27,10 @@ version = "5.2.2-SNAPSHOT"
 description = "A fully customisable staff communication plugin for BungeeCord!"
 
 repositories {
+    maven("https://repo.hypera.dev/mirror/") // Needed to resolve com.mojang:brigadier (mirrors libraries.minecraft.net).
+    maven("https://repo.hypera.dev/releases/")
     mavenCentral()
     sonatype.ossSnapshots()
-    maven("https://repo.hypera.dev/releases/")
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ adventure = "4.16.0"
 adventure-platform = "4.3.2"
 
 # Platforms
-platform-bungeecord = "1.20-R0.1-SNAPSHOT"
+platform-bungeecord = "1.20-R0.3-SNAPSHOT"
 
 # Dependencies
 updatelib = "4.0.0"

--- a/src/main/java/dev/hypera/ultrastaffchat/events/staff/StaffJoinEvent.java
+++ b/src/main/java/dev/hypera/ultrastaffchat/events/staff/StaffJoinEvent.java
@@ -20,27 +20,33 @@ package dev.hypera.ultrastaffchat.events.staff;
 
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.connection.Server;
-import net.md_5.bungee.api.event.PostLoginEvent;
 import net.md_5.bungee.api.plugin.Cancellable;
+import net.md_5.bungee.api.plugin.Event;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player with the permission `staffchat.join` joins the proxy. When cancelled, the staff join message is
  * not shown.
  */
-public class StaffJoinEvent extends PostLoginEvent implements Cancellable {
+public class StaffJoinEvent extends Event implements Cancellable {
 
 	private boolean cancelled = false;
+	private final ProxiedPlayer player;
 	private final Server server;
 
 	@Deprecated
-	public StaffJoinEvent(ProxiedPlayer player) {
+	public StaffJoinEvent(@NotNull ProxiedPlayer player) {
 		this(player, player.getServer());
 	}
 
-	public StaffJoinEvent(ProxiedPlayer player, Server server) {
-		super(player);
+	public StaffJoinEvent(@NotNull ProxiedPlayer player, Server server) {
+		this.player = player;
 		this.server = server;
+	}
+
+	public @NotNull ProxiedPlayer getPlayer() {
+		return player;
 	}
 
 	@ApiStatus.Experimental


### PR DESCRIPTION
**Summary**
Update BungeeCord to `1.20-R0.3-SNAPSHOT` and fix StaffJoinEvent.

BungeeCord broke their API by changing the PostLoginEvent to an AsyncEvent and adding a new field (which breaks the lombok `@Data` constructor, thus breaking StaffJoinEvent): https://github.com/SpigotMC/BungeeCord/commit/17e23d5c3f1d3aa0bbd6497c7839b780e88ae053

**Changes**
- Update `bungeecord-api` to `1.20-R0.3-SNAPSHOT`
- Change `StaffJoinEvent` to no longer extend `PostLoginEvent` and add `getPlayer()` method to `StaffJoinEvent` (instead of using the method from `PostLoginEvent`).

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [GNU General Public License v3 or later](https://github.com/HyperaDev/UltraStaffChat/blob/main/LICENSE).
- [x] I have read and agree to follow the [Code of Conduct](https://github.com/HyperaDev/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

**Breaking change**
`StaffJoinEvent` no longer extends the BungeeCord `PostLoginEvent` class.
This change should not break any plugins using the API unless they are attempting to use the `StaffJoinEvent` as a `PostLoginEvent` (e.g. by casting), which is unlikely and is not recommended.

Due to this breakage originally being caused by BungeeCord, and the unlikeliness of an API user requiring `StaffJoinEvent` to extend `PostLoginEvent`, this change will be released in v5.2.2 and no major version bump will occur.
It is highly unlikely that this will actually break anything using the API.
